### PR TITLE
Fixed bias unit.

### DIFF
--- a/rbm.py
+++ b/rbm.py
@@ -34,6 +34,7 @@ class RBM:
       # (This is the "positive CD phase", aka the reality phase.)
       pos_hidden_activations = np.dot(data, self.weights)      
       pos_hidden_probs = self._logistic(pos_hidden_activations)
+      pos_hidden_probs[:,0] = 1 # Fix the bias unit.
       pos_hidden_states = pos_hidden_probs > np.random.rand(num_examples, self.num_hidden + 1)
       # Note that we're using the activation *probabilities* of the hidden states, not the hidden states       
       # themselves, when computing associations. We could also use the states; see section 3 of Hinton's 


### PR DESCRIPTION
Set hidden bias unit probability to 1 before sampling its positive state.
